### PR TITLE
feat: add allowExportNewColumns config and fix column visibility export behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 package-lock.json
 
 code.sh
+out

--- a/README.md
+++ b/README.md
@@ -1374,6 +1374,41 @@ The system includes comprehensive formatting utilities:
 
 For complete documentation and examples, see [Export Customization Guide](./docs/EXPORT_CUSTOMIZATION.md).
 
+#### Controlling Export Column Behavior
+
+The `allowExportNewColumns` configuration option gives you fine-grained control over which columns are included in exports:
+
+**When `allowExportNewColumns: true` (default):**
+- ✅ Exports visible table columns
+- ❌ Excludes hidden table columns (always)
+- ✅ Includes new columns created by transform function
+
+**When `allowExportNewColumns: false`:**
+- ✅ Exports visible table columns only
+- ❌ Excludes hidden table columns (always)
+- ❌ Excludes new columns from transform function
+
+```typescript
+// Example: Only export what user can see in the table
+config={{
+  allowExportNewColumns: false, // Strict mode - visible columns only
+  enableColumnVisibility: true, // Allow users to hide/show columns
+}}
+
+// Example: Include calculated columns in export (default)
+config={{
+  allowExportNewColumns: true, // Include transform function columns
+  enableColumnVisibility: true,
+}}
+```
+
+**Use Cases:**
+
+- **Strict Mode (`false`)**: When you want exports to match exactly what users see in the table
+- **Enhanced Mode (`true`)**: When you want to provide additional calculated data in exports that doesn't need to be displayed in the table UI
+
+**Note:** Hidden columns are always excluded from exports regardless of this setting. This option only controls whether new columns from the transform function are included.
+
 ---
 
 ## Server Implementation
@@ -2339,6 +2374,7 @@ const firstItem = data?.items?.[0]?.title ?? "No items";
 | `enableUrlState`           | `boolean`                   | `true`      | Save table state in URL                  |
 | `columnResizingTableId`    | `string`                    | -           | ID for column resizing persistence       |
 | `searchPlaceholder`        | `string`                    | -           | Custom placeholder text for search input |
+| `allowExportNewColumns`    | `boolean`                   | `true`      | Allow exporting new columns from transform function |
 | `size`                     | `'sm' \| 'default' \| 'lg'` | `'default'` | Size for buttons and inputs in the table |
 
 The `size` prop affects the following components:

--- a/src/components/data-table/toolbar.tsx
+++ b/src/components/data-table/toolbar.tsx
@@ -406,6 +406,7 @@ export function DataTableToolbar<TData extends ExportableData>({
             headers={headers}
             transformFunction={transformFunction}
             size={config.size}
+            config={config}
           />
         )}
 

--- a/src/components/data-table/utils/table-config.ts
+++ b/src/components/data-table/utils/table-config.ts
@@ -50,6 +50,12 @@ export interface TableConfig {
   // Custom placeholder text for search input
   // If not provided, defaults to "Search {entityName}..."
   searchPlaceholder?: string;
+  
+  // Allow exporting new columns created by transform function
+  // When true (default): Export includes visible columns + new columns from transform function
+  // When false: Export only includes visible columns (hidden columns always excluded)
+  // Note: Hidden columns are ALWAYS excluded regardless of this setting
+  allowExportNewColumns: boolean;
 }
 
 // Default configuration
@@ -69,6 +75,7 @@ const defaultConfig: TableConfig = {
   size: 'default',                // Default size for buttons and inputs
   columnResizingTableId: undefined, // No table ID by default
   searchPlaceholder: undefined,   // No custom search placeholder by default
+  allowExportNewColumns: true,    // Allow new columns from transform function by default
 };
 
 /**

--- a/src/components/data-table/view-options.tsx
+++ b/src/components/data-table/view-options.tsx
@@ -53,7 +53,6 @@ export function DataTableViewOptions<TData>({
   // Order columns based on the current table column order
   const columnOrder = table.getState().columnOrder;
   const orderedColumns = useMemo(() => {
-
     if (!columnOrder.length) {
       return columns;
     }
@@ -93,6 +92,17 @@ export function DataTableViewOptions<TData>({
       console.error("Error saving column order:", error);
     }
   }, []);
+
+  // Handle column visibility toggle
+  const handleColumnVisibilityToggle = useCallback((columnId: string) => {
+    const currentVisibility = table.getState().columnVisibility;
+    const isCurrentlyVisible = currentVisibility[columnId] !== false;
+    
+    table.setColumnVisibility({
+      ...currentVisibility,
+      [columnId]: !isCurrentlyVisible,
+    });
+  }, [table]);
 
   // Handle drag start
   const handleDragStart = useCallback((e: React.DragEvent, columnId: string) => {
@@ -183,7 +193,7 @@ export function DataTableViewOptions<TData>({
               {orderedColumns.map((column) => (
                 <CommandItem
                   key={column.id}
-                  onSelect={() => column.toggleVisibility(!column.getIsVisible())}
+                  onSelect={() => handleColumnVisibilityToggle(column.id)}
                   draggable
                   onDragStart={(e) => handleDragStart(e, column.id)}
                   onDragOver={handleDragOver}


### PR DESCRIPTION

  - Add `allowExportNewColumns` config option for granular export control
  - Fix column visibility export to always exclude hidden columns
  - Resolve multi-column visibility toggle issues
  - Update documentation with new configuration